### PR TITLE
Add `.md` suffix to license extensions.

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -11,6 +11,7 @@ const LICENSE_BASE_NAMES: &[&str] = &[
 const LICENSE_EXTENSIONS: &[&str] = &[
     "",
     ".txt",
+    ".md"
 ];
 
 #[derive(Debug, Copy, Clone, Serialize)]


### PR DESCRIPTION
It is common for many licenses to end in `.md`, especially in GitHub. This pull request will also identify Markdown files.